### PR TITLE
Add python_require version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
     ),
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Tells pip and al. that this tool won't work on versions older than 3.6